### PR TITLE
Fix issues with deleting notes that haven't been added to the server

### DIFF
--- a/Networking/NoteSessionManager.swift
+++ b/Networking/NoteSessionManager.swift
@@ -431,7 +431,10 @@ class NoteSessionManager {
     func delete(note: NoteProtocol, completion: SyncCompletionBlock? = nil) {
         var incoming = note
         incoming.deleteNeeded = true
-        if NoteSessionManager.isOnline {
+        if incoming.addNeeded {
+            CDNote.delete(note: incoming)
+            completion?()
+        } else if NoteSessionManager.isOnline {
             deleteOnServer(incoming) { [weak self] result in
                 switch result {
                 case .success( _):

--- a/iOCNotes/CoreData/CDNote+CoreDataClass.swift
+++ b/iOCNotes/CoreData/CDNote+CoreDataClass.swift
@@ -234,7 +234,13 @@ public class CDNote: NSManagedObject {
         NotesData.mainThreadContext.performAndWait {
             let request: NSFetchRequest<CDNote> = CDNote.fetchRequest()
             do {
-                request.predicate = NSPredicate(format: "cdId == %d", note.id)
+                let predicate: NSPredicate
+                if note.id >= 0 {
+                    predicate = NSPredicate(format: "cdId == %d", note.id)
+                } else {
+                    predicate = NSPredicate(format: "cdGuid == %@", note.guid ?? "")
+                }
+                request.predicate = predicate
                 let records = try NotesData.mainThreadContext.fetch(request)
                 if let existingRecord = records.first {
                     NotesData.mainThreadContext.delete(existingRecord)


### PR DESCRIPTION
This change includes two fixes for adding and deleting notes while in offline mode.

1. Use guid when deleting a note when it doesn't have a valid id.
2. When deleting note, if it still needs to be added to the server, delete it immediately from CoreData, as there is no need to try and delete it on the server.