### PR TITLE
Fix issues with Copy to CloudNotes when offline

### DIFF
--- a/iOCNotes/NotesTableViewController.swift
+++ b/iOCNotes/NotesTableViewController.swift
@@ -39,6 +39,7 @@ class NotesTableViewController: UITableViewController {
     private var observers = [NSObjectProtocol]()
     private var sectionCollapsedInfo = ExpandableSectionType()
     private var isSyncing = false
+    private var noteToAddOnViewDidLoad: String?
 
     private var contextMenuIndexPath: IndexPath?
     
@@ -165,6 +166,10 @@ class NotesTableViewController: UITableViewController {
         tableView.backgroundView = UIView()
         tableView.dropDelegate = self
         updateSectionExpandedInfo()
+        if let noteToAddOnViewDidLoad = noteToAddOnViewDidLoad {
+            addNote(content: noteToAddOnViewDidLoad)
+            self.noteToAddOnViewDidLoad = nil
+        }
         tableView.reloadData()
         definesPresentationContext = true
         refreshBarButton.isEnabled = NoteSessionManager.isOnline
@@ -471,6 +476,10 @@ class NotesTableViewController: UITableViewController {
     }
     
     func addNote(content: String) {
+        guard isViewLoaded else {
+            noteToAddOnViewDidLoad = content
+            return
+        }
         HUD.show(.progress)
         NoteSessionManager.shared.add(content: content, category: "", completion: { [weak self] note in
             if note != nil {


### PR DESCRIPTION
This PR contains two bug fixes for using the Copy to CloudNotes feature in offline mode:

1. If the app isn't running, it would crash when using Copy to CloudNotes in offline mode. This was because we were trying to access results from the fetch results controller before any were fetched. Now we wait until viewDidLoad to add the new note.
2. If the app was put in the background and then we use Copy to CloudNotes in offline mode, the new note wouldn't appear. This was because the fetch results controller delegate wasn't hooked back up again before the new note was added. Now we set the delegate before adding the new note.