### PR TITLE
quick French translation for missing entries

### DIFF
--- a/iOCNotes/fr.lproj/Categories.strings
+++ b/iOCNotes/fr.lproj/Categories.strings
@@ -1,6 +1,6 @@
 
 /* Class = "UINavigationItem"; title = "Categories"; ObjectID = "A3w-VO-pFV"; */
-"A3w-VO-pFV.title" = "Categories";
+"A3w-VO-pFV.title" = "Catégories";
 
 /* Class = "UILabel"; text = "Title"; ObjectID = "xvw-8P-Q58"; */
-"xvw-8P-Q58.text" = "Title";
+"xvw-8P-Q58.text" = "Titre";

--- a/iOCNotes/fr.lproj/Localizable.strings
+++ b/iOCNotes/fr.lproj/Localizable.strings
@@ -144,62 +144,62 @@
 "You are now connected to Notes on your server" = "You are now connected to Notes on your server";
 
 /* Acknowledgements */
-"Acknowledgements" = "";
+"Acknowledgements" = "Remerciements";
 
 /* Title of alert for adding a category */
-"Add Category" = "";
+"Add Category" = "Ajouter une catégorie";
 
 /* Item to show all notes */
-"All" = "";
+"All" = "Toutes";
 
 /* Header title, categories */
-"CATEGORIES" = "";
+"CATEGORIES" = "CATEGORIES";
 
 /* 'Category' menu item */
-"Category" = "";
+"Category" = "Catégorie";
 
 /* Action to change category of a note */
-"Category..." = "";
+"Category..." = "Catégorie...";
 
 /* Action to change category of a note */
-"Change Category..." = "";
+"Change Category..." = "Changer de Catégorie";
 
 /* Status information, connected */
-"Connected to Notes on the server" = "";
+"Connected to Notes on the server" = "Connecté au serveur";
 
 /* Action to delete a note */
-"Delete" = "";
+"Delete" = "Supprimer";
 
 /* Prompt on alert for adding a category */
-"Enter a name for the new category" = "";
+"Enter a name for the new category" = "Saisissez un nom pour la nouvelle catégorie";
 
 /* Item to show favorite notes */
-"Favorites" = "";
+"Favorites" = "Favoris";
 
 /* Header title, main */
-"MAIN" = "";
+"MAIN" = "PRINCIPAL";
 
 /* Status information, not connected */
-"Not connected to Notes on a server" = "";
+"Not connected to Notes on a server" = "Déconnecté du serveur";
 
 /* Message about not being logged in */
-"Not logged in" = "";
+"Not logged in" = "Utilisateur non connecté";
 
 /* Title of alert to change title */
-"Note Title" = "";
+"Note Title" = "Titre de la note";
 
 /* Button, OK */
-"OK" = "";
+"OK" = "OK";
 
 /* Action to change title of a note
    Caption of Rename button */
-"Rename" = "";
+"Rename" = "Renommer";
 
 /* Message of alert to change title */
-"Rename the note" = "";
+"Rename the note" = "Renommer la note";
 
 /* Action to change title of a note */
-"Rename..." = "";
+"Rename..." = "Renommer...";
 
 /* Message with Notes version, product name and version */
-"Using Notes %@on %@ %@." = "";
+"Using Notes %@on %@ %@." = "Utilise Notes %@ sur %@ %@.";

--- a/iOCNotes/fr.lproj/Main_iPhone.strings
+++ b/iOCNotes/fr.lproj/Main_iPhone.strings
@@ -1,9 +1,9 @@
 
 /* Class = "UILabel"; text = "Title"; ObjectID = "1Q3-he-nuB"; */
-"1Q3-he-nuB.text" = "Title";
+"1Q3-he-nuB.text" = "Titre";
 
 /* Class = "UINavigationItem"; title = "Notes"; ObjectID = "qfr-a2-foZ"; */
 "qfr-a2-foZ.title" = "Notes";
 
 /* Class = "UILabel"; text = "Subtitle"; ObjectID = "x61-QN-GPh"; */
-"x61-QN-GPh.text" = "Subtitle";
+"x61-QN-GPh.text" = "Sous-titre";


### PR DESCRIPTION
This PR fixes empty labels on iPhone with French display language.
Please use the English text instead of empty translations, to avoid empty buttons and menu items.